### PR TITLE
Modified message for completed kills

### DIFF
--- a/addons/monstertracker/monstertracker.lua
+++ b/addons/monstertracker/monstertracker.lua
@@ -69,7 +69,11 @@ function FPS_ON_MSG_HOOKED(frame, msg, argStr, argNum)
 
 			local killNoticeText = killNoticeFrame:GetChild("killNoticeText");
 			tolua.cast(killNoticeText, "ui::CRichText");
-			killNoticeText:SetText("{@st42}" .. ADD_THOUSANDS_SEPARATOR(monsterTrackData.killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(monsterTrackData.killsRequired) .. " " .. monCls.Name .. " killed{/}");
+			if monsterTrackData.killCount < monsterTrackData.killsRequired then
+				killNoticeText:SetText("{@st42}" .. ADD_THOUSANDS_SEPARATOR(monsterTrackData.killCount) .. " / " .. ADD_THOUSANDS_SEPARATOR(monsterTrackData.killsRequired) .. " " .. monCls.Name .. " killed{/}");
+			else
+				killNoticeText:SetText("{@st42}" ..  monCls.Name .. " complete ("..ADD_THOUSANDS_SEPARATOR(monsterTrackData.killCount).."){/}");
+			end
 			killNoticeText:SetGravity(ui.LEFT, ui.TOP);
 			killNoticeText:SetTextAlign("left", "top");
 			killNoticeText:Move(0, 0);


### PR DESCRIPTION
No point in showing target for journal if user already has the achievement.
It's just easier to see whether you have killed enough if the message is different. And you can still see the number of kills for grinding purposes.